### PR TITLE
SceneManager and jenny.properties fix (issue #35)

### DIFF
--- a/Assets/Libraries/PRNG.meta
+++ b/Assets/Libraries/PRNG.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 801ec135020798f47b32eb659eecf624
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Libraries/PRNG/Mt19937.cs.meta
+++ b/Assets/Libraries/PRNG/Mt19937.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e794b6eec81bd7e429c2b91d30a54026
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CameraMove.cs
+++ b/Assets/Scripts/CameraMove.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Enums;
 
 public class CameraMove : MonoBehaviour
 {
@@ -8,7 +9,7 @@ public class CameraMove : MonoBehaviour
 
     void Awake()
     {
-        SceneManager.Instance.Register(this.GetType().Name);
+        SceneManager.Instance.Register(this, SceneObjectType.SceneObjectTypeUtilityScript);
     }
 
     void Update()

--- a/Assets/Scripts/ImageTest.cs
+++ b/Assets/Scripts/ImageTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using System.IO;
+using Enums;
 
 //MonoBehaviors should be in Asset/Script folder?
 namespace ImageLoader
@@ -17,6 +18,7 @@ namespace ImageLoader
         {
             ImageLoaderManager = new TileSpriteImageLoaderManager();
             SpriteSheetLoaderManager = new SpriteSheetImageLoader();
+            SceneManager.Instance.Register(this, SceneObjectType.SceneObjectTypeUtilityScript);
         }
         private void Start() 
         {

--- a/Assets/src/SceneManager/SceneManager.cs
+++ b/Assets/src/SceneManager/SceneManager.cs
@@ -1,9 +1,25 @@
 using UnityEngine;
 using System.Collections.Generic;
+using Enums;
 
-public class SceneManager : MonoBehaviour
+
+
+// helper class to store  mono objects
+public class SceneManagerObject
 {
-    private List<string> objects = new List<string>();
+    public object obj { get; set; }
+    public SceneObjectType type { get; set; }
+
+    public SceneManagerObject(object o, SceneObjectType typ)
+    {
+        obj = o;
+        type = typ;
+    }
+}
+
+class SceneManager : MonoBehaviour
+{
+    private List<SceneManagerObject> objects = new List<SceneManagerObject>();
 
     private static SceneManager _instance;
     public static SceneManager Instance
@@ -26,14 +42,20 @@ public class SceneManager : MonoBehaviour
 
 
     //add object to the list
-    public void Register(string typeName)
+    public int Register(object obj, SceneObjectType type)
     {
-        objects.Add(typeName);
+        SceneManagerObject newObject = new SceneManagerObject(obj, type);
+        objects.Add(newObject);
+
+        return objects.Count - 1;
     }
 
     //remove object from the list
-    public void Unregister(string typeName)
+    public void Unregister(int id)
     {
-        objects.Remove(typeName);
+        if (objects.Count < id)
+        {
+            objects.RemoveAt(id);
+        }
     }
 }

--- a/Assets/src/enums/Scene-objects.cs
+++ b/Assets/src/enums/Scene-objects.cs
@@ -2,7 +2,7 @@
 namespace Enums
 {
 
-    enum SceneObjectType  : int
+    public enum SceneObjectType  : int
     {
         SceneObjectTypeError = 0, //
         SceneObjectTypeUtilityScript = 1 , //


### PR DESCRIPTION
this is the updated version of  pull request #55 https://github.com/kk-digital/kcg/pull/55

I copy pasted the previous files in a new branch. And now the jenny.properties are reverted.

Everything is the same from the previous changes made to SceneManager, the only addition is the abstract pointer to monobehavior classes that was added in SceneManager.