### PR TITLE
Fix jenny

### DIFF
--- a/Jenny.properties
+++ b/Jenny.properties
@@ -61,3 +61,4 @@ Entitas.CodeGeneration.Plugins.Contexts = Game, \
 
 Entitas.CodeGeneration.Plugins.IgnoreNamespaces = true
 DesperateDevs.CodeGeneration.Plugins.TargetDirectory = Assets/Entitas/Generated
+Entitas.CodeGeneration.Plugins.Assemblies = Library/ScriptAssemblies/Assembly-CSharp.dll

--- a/Jenny.properties
+++ b/Jenny.properties
@@ -1,9 +1,6 @@
 Jenny.SearchPaths = Jenny/Plugins/DesperateDevs, \
                     Jenny/Plugins/Entitas, \
-                    Jenny/Plugins/Entitas.Roslyn, \
-                    Jenny\Plugins\DesperateDevs, \
-                    Jenny\Plugins\Entitas, \
-                    Jenny\Plugins\Entitas.Roslyn
+                    Jenny/Plugins/Entitas.Roslyn
 
 Jenny.Plugins = DesperateDevs.CodeGeneration.Plugins, \
                 DesperateDevs.CodeGeneration.Unity.Plugins, \
@@ -12,15 +9,12 @@ Jenny.Plugins = DesperateDevs.CodeGeneration.Plugins, \
                 Entitas.VisualDebugging.CodeGeneration.Plugins
 
 Jenny.PreProcessors = DesperateDevs.CodeGeneration.Plugins.ValidateProjectPathPreProcessor, \
-                      DesperateDevs.CodeGeneration.Plugins.TargetFrameworkProfilePreProcessor, \
-                      DesperateDevs.CodeGeneration.Unity.Plugins.WarnIfCompilationErrorsPreProcessor
+                      DesperateDevs.CodeGeneration.Plugins.TargetFrameworkProfilePreProcessor
 
 Jenny.DataProviders = Entitas.Roslyn.CodeGeneration.Plugins.ComponentDataProvider, \
                       Entitas.CodeGeneration.Plugins.ContextDataProvider, \
                       Entitas.Roslyn.CodeGeneration.Plugins.EntityIndexDataProvider, \
-                      Entitas.Roslyn.CodeGeneration.Plugins.CleanupDataProvider, \
-                      Entitas.CodeGeneration.Plugins.ComponentDataProvider, \
-                      Entitas.CodeGeneration.Plugins.EntityIndexDataProvider
+                      Entitas.Roslyn.CodeGeneration.Plugins.CleanupDataProvider
 
 Jenny.CodeGenerators = Entitas.CodeGeneration.Plugins.ComponentContextApiGenerator, \
                        Entitas.CodeGeneration.Plugins.ComponentEntityApiGenerator, \
@@ -50,8 +44,7 @@ Jenny.PostProcessors = DesperateDevs.CodeGeneration.Plugins.AddFileHeaderPostPro
                        DesperateDevs.CodeGeneration.Plugins.NewLinePostProcessor, \
                        DesperateDevs.CodeGeneration.Plugins.UpdateCSProjPostProcessor, \
                        DesperateDevs.CodeGeneration.Plugins.WriteToDiskPostProcessor, \
-                       DesperateDevs.CodeGeneration.Plugins.ConsoleWriteLinePostProcessor, \
-                       DesperateDevs.CodeGeneration.Unity.Plugins.DebugLogPostProcessor
+                       DesperateDevs.CodeGeneration.Plugins.ConsoleWriteLinePostProcessor
 
 Jenny.Server.Port = 3333
 Jenny.Client.Host = localhost
@@ -61,4 +54,3 @@ Entitas.CodeGeneration.Plugins.Contexts = Game, \
 
 Entitas.CodeGeneration.Plugins.IgnoreNamespaces = true
 DesperateDevs.CodeGeneration.Plugins.TargetDirectory = Assets/Entitas/Generated
-Entitas.CodeGeneration.Plugins.Assemblies = Library/ScriptAssemblies/Assembly-CSharp.dll


### PR DESCRIPTION
I have run Auto-Import and Removed the Non-Roslyn Dependencies again.

Please allow me to explain, why I have made this decision / how Jenny works:

Jenny comes with 3 kinds of Generators:
IPreProcessor: To prepare Code Generation, e.g. Validate Settings etc.
IDataProvider: To provide GeneratorData for CodeGenerators. This is used to allow different Sources to provide information for what's to Generate.
ICodeGenerator: To provide CodeGenFiles which contain paths and contents of files to be generated
IPostProcessors: To modify the CodeGenFiles, e.g. add some Header-Comments, merge files with the same Path and Write the Files to the Disk.


For IDataProviders, Jenny comes with multiple implementations.
Entitas.CodeGeneration.Plugins uses .NET's Reflection (Type Introspection) in order to get information about Component-Attributes from a Compiled Assembly.
Entitas.Roslyn.CodeGeneration.Plugins uses Microsoft's Roslyn Code Analyzer to get information about Component-Attributes directly from your C# Source Code.

This means, that the latter works, even if you have File Conflicts / Compile Errors. Before the latter Code Generator existed, after merging two conflicting branches, the process would be to spend 30 minutes to resolve all compile errors by commenting out a lot of code, then compile, then Generate, then compile again, then uncomment all the commented out code again.

Thanks to Roslyn, you can just hit Generate after merging two conflicting branches and often, the conflicts will resolve themselves.

I have configured your Jenny.properties in a way that you can simply use `./Jenny-Generate.bat` to Generate Code. Add it to External Tools to your Favorite IDE and add a Keyboard Shortcut, so you can Generate Code while writing Code in your IDE.

When using Jenny-Auto-Import, please make sure to not have any conflicting DataProviders, e.g. Entitas.CodeGeneration.Plugin.ComponentDataProvider and Entitas.Roslyn.CodeGeneration.Plugins.ComponentDataProvider, as you'll else end up with duplicate CodeGeneratorData being passed on by the IDataProviders to the ICodeGenerators.

Please let me know, whether you have any additional question.

Tagging @zoubirabde9a, because you made changes to `Jenny.properties` and you probably had some valid reasons for doing so.