### PR TITLE
Camera Zooming in Pixel Perfect Camera Bug Fixed

### DIFF
--- a/Assets/Scenes/MapLoaderTest-MoonBunker.unity
+++ b/Assets/Scenes/MapLoaderTest-MoonBunker.unity
@@ -268,7 +268,7 @@ Camera:
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 1.875
+  orthographic size: 1.3619791
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -326,10 +326,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   maxCameraHalfWidthEnabled: 1
   maxCameraHalfHeightEnabled: 1
-  maxCameraHalfWidth: 6
-  maxCameraHalfHeight: 3
-  targetDimension: 1
-  targetCameraHalfWidth: 2
+  maxCameraHalfWidth: 41.32
+  maxCameraHalfHeight: 58.2
+  targetDimension: 0
+  targetCameraHalfWidth: 3
   targetCameraHalfHeight: 2
   pixelPerfect: 1
   assetsPixelsPerUnit: 32
@@ -390,5 +390,48 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cbcde75a8691ce94e982bf1c6b37fd7b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TileMap: Moonbunker/Moon Bunker.tmx
   Material: {fileID: 2100000, guid: 4073de6af124b4f40bdce02691603836, type: 2}
+--- !u!1 &1572100629
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1572100631}
+  - component: {fileID: 1572100630}
+  m_Layer: 0
+  m_Name: InputManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1572100630
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1572100629}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6e322dc68291adc488ca1b1b9971e20b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1572100631
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1572100629}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.89, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/PixelPerfectCameraTest.unity
+++ b/Assets/Scenes/PixelPerfectCameraTest.unity
@@ -179,7 +179,7 @@ Camera:
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 2.61
+  orthographic size: 1.3619791
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -237,13 +237,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   maxCameraHalfWidthEnabled: 1
   maxCameraHalfHeightEnabled: 1
-  maxCameraHalfWidth: 500
-  maxCameraHalfHeight: 500
-  targetDimension: 1
-  targetCameraHalfWidth: 2
+  maxCameraHalfWidth: 41.32
+  maxCameraHalfHeight: 58.2
+  targetDimension: 0
+  targetCameraHalfWidth: 3
   targetCameraHalfHeight: 2
   pixelPerfect: 1
-  assetsPixelsPerUnit: 100
+  assetsPixelsPerUnit: 32
 --- !u!114 &519420036
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CameraInfo.cs
+++ b/Assets/Scripts/CameraInfo.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Collections;
 using UnityEngine;
 using Enums;
 #if UNITY_EDITOR

--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -29,19 +29,22 @@ public class InputManager : MonoBehaviour
     // On Key Pressed
     private void OnKeyPressed()
     {
-        
         // Increase Zoom with +
         if (activeKey.keyName == KeyCode.KeypadPlus.ToString())
         {
-            CameraInfo camInfo = Camera.main.GetComponent<CameraInfo>();
-            camInfo.IncreaseZoom();
+            PixelPerfectCameraTestTool pixelCam = Camera.main.GetComponent<PixelPerfectCameraTestTool>();
+            if(pixelCam.targetCameraHalfWidth < 15.0f)
+                pixelCam.targetCameraHalfWidth += 1.0f;
+            pixelCam.adjustCameraFOV();
         }
 
         // Decrease zoom with -
         if (activeKey.keyName == KeyCode.KeypadMinus.ToString())
         {
-            CameraInfo camInfo = Camera.main.GetComponent<CameraInfo>();
-            camInfo.DecreaseZoom();
+            PixelPerfectCameraTestTool pixelCam = Camera.main.GetComponent<PixelPerfectCameraTestTool>();
+            if(pixelCam.targetCameraHalfWidth > 0.1f)
+                pixelCam.targetCameraHalfWidth -= 1.0f;
+            pixelCam.adjustCameraFOV();
         }
     }
 

--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -4,7 +4,7 @@ using Enums;
 public class InputManager : MonoBehaviour
 {
     // Key struct to keep key settings
-    struct Key
+    public struct Key
     {
         public KeyCode keyCode;
         public eKeyEvent keyEvent;
@@ -15,8 +15,9 @@ public class InputManager : MonoBehaviour
     private eInputDevice inputDevice;
 
     // Currently Active Key
-    private Key activeKey;
+    public Key activeKey;
 
+    // Doc: https://docs.unity3d.com/ScriptReference/MonoBehaviour.Awake.html
     void Awake()
     {
         //Check if Scene has SceneManager setup
@@ -26,7 +27,7 @@ public class InputManager : MonoBehaviour
         }
     }
 
-    // On Key Pressed
+    // Event: On Key Pressed
     private void OnKeyPressed()
     {
         // Increase Zoom with +
@@ -35,6 +36,7 @@ public class InputManager : MonoBehaviour
             PixelPerfectCameraTestTool pixelCam = Camera.main.GetComponent<PixelPerfectCameraTestTool>();
             if(pixelCam.targetCameraHalfWidth < 15.0f)
                 pixelCam.targetCameraHalfWidth += 1.0f;
+            // Update Zoomed ortho pixel perfect calculation
             pixelCam.adjustCameraFOV();
         }
 
@@ -42,19 +44,17 @@ public class InputManager : MonoBehaviour
         if (activeKey.keyName == KeyCode.KeypadMinus.ToString())
         {
             PixelPerfectCameraTestTool pixelCam = Camera.main.GetComponent<PixelPerfectCameraTestTool>();
-            if(pixelCam.targetCameraHalfWidth > 0.1f)
+            if(pixelCam.targetCameraHalfWidth > 1.5f)
                 pixelCam.targetCameraHalfWidth -= 1.0f;
+            // Update Zoomed ortho pixel perfect calculation
             pixelCam.adjustCameraFOV();
         }
     }
 
-    // On Key Released
+    // Event: On Key Released
     private void OnKeyReleased()
     {
-        if(activeKey.keyName == KeyCode.KeypadPlus.ToString())
-        {
-            Debug.Log(activeKey.keyName + " Released");
-        }
+        
     }
 
     // Doc: https://docs.unity3d.com/ScriptReference/MonoBehaviour.FixedUpdate.html
@@ -126,6 +126,8 @@ public class InputManager : MonoBehaviour
             return eInputDevice.KeyboardMouse;
         }
 
+        // Else, return none device.
         return eInputDevice.Invalid;
     }
 }
+

--- a/Assets/src/Enum/Inputs.cs
+++ b/Assets/src/Enum/Inputs.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Enums
 {
     // Enum for detecting player's input device


### PR DESCRIPTION
When you zoom the camera, in the old system. Because it is not working together with the pixel perfect camera, the tile edges was looking sharp and kind of pixel bugged. No worries, it's fixed now.