### PR TITLE
Ticket #147: Player State Added

### DIFF
--- a/Assets/Scripts/InputManager.cs
+++ b/Assets/Scripts/InputManager.cs
@@ -14,6 +14,9 @@ public class InputManager : MonoBehaviour
     // Input Device
     private eInputDevice inputDevice;
 
+    // Player State
+    private PlayerState playerState;
+
     // Currently Active Key
     public Key activeKey;
 
@@ -30,31 +33,45 @@ public class InputManager : MonoBehaviour
     // Event: On Key Pressed
     private void OnKeyPressed()
     {
-        // Increase Zoom with +
-        if (activeKey.keyName == KeyCode.KeypadPlus.ToString())
+        if(playerState == PlayerState.Pedestrian)
         {
-            PixelPerfectCameraTestTool pixelCam = Camera.main.GetComponent<PixelPerfectCameraTestTool>();
-            if(pixelCam.targetCameraHalfWidth < 15.0f)
-                pixelCam.targetCameraHalfWidth += 1.0f;
-            // Update Zoomed ortho pixel perfect calculation
-            pixelCam.adjustCameraFOV();
-        }
+            // Increase Zoom with +
+            if (activeKey.keyName == KeyCode.KeypadPlus.ToString())
+            {
+                PixelPerfectCameraTestTool pixelCam = Camera.main.GetComponent<PixelPerfectCameraTestTool>();
+                if(pixelCam.targetCameraHalfWidth < 15.0f)
+                    pixelCam.targetCameraHalfWidth += 1.0f;
+                // Update Zoomed ortho pixel perfect calculation
+                pixelCam.adjustCameraFOV();
+            }
 
-        // Decrease zoom with -
-        if (activeKey.keyName == KeyCode.KeypadMinus.ToString())
+            // Decrease zoom with -
+            if (activeKey.keyName == KeyCode.KeypadMinus.ToString())
+            {
+                PixelPerfectCameraTestTool pixelCam = Camera.main.GetComponent<PixelPerfectCameraTestTool>();
+                if(pixelCam.targetCameraHalfWidth > 1.5f)
+                    pixelCam.targetCameraHalfWidth -= 1.0f;
+                // Update Zoomed ortho pixel perfect calculation
+                pixelCam.adjustCameraFOV();
+            }
+        }
+        else if(playerState == PlayerState.Vehicle)
         {
-            PixelPerfectCameraTestTool pixelCam = Camera.main.GetComponent<PixelPerfectCameraTestTool>();
-            if(pixelCam.targetCameraHalfWidth > 1.5f)
-                pixelCam.targetCameraHalfWidth -= 1.0f;
-            // Update Zoomed ortho pixel perfect calculation
-            pixelCam.adjustCameraFOV();
+
         }
     }
 
     // Event: On Key Released
     private void OnKeyReleased()
     {
-        
+        if(playerState == PlayerState.Pedestrian)
+        {
+
+        }
+        else if(playerState == PlayerState.Vehicle)
+        {
+
+        }
     }
 
     // Doc: https://docs.unity3d.com/ScriptReference/MonoBehaviour.FixedUpdate.html

--- a/Assets/src/Enum/Inputs.cs
+++ b/Assets/src/Enum/Inputs.cs
@@ -15,4 +15,12 @@ namespace Enums
         Release,
         Invalid
     }
+
+
+    // Enum for specifing player state to assign inputs
+    public enum PlayerState
+    {
+        Pedestrian,
+        Vehicle
+    }
 }


### PR DESCRIPTION
Player state added to determine, where inputs going to work. For example, the same key event can work in different situations. Like, car movement and player movement key might be same. To separate them, we add player state enum.