### PR TITLE
More sprite atlas changes

### DIFF
--- a/Assets/Scripts/MapLoaderTestScript.cs
+++ b/Assets/Scripts/MapLoaderTestScript.cs
@@ -166,9 +166,9 @@ namespace PlanetTileMap.Unity
             GameState.SpriteLoader.GetSpriteSheetID("Assets\\StreamingAssets\\assets\\sprite\\item\\admin_icon_pipesim.png",
             16, 16);
 
-            int PipeSpriteIndex = GameState.SpriteAtlasManager.CopySpriteToAtlas(PipeTileSheet, 0, 0, 0);
+            int PipeSpriteIndex = GameState.SpriteAtlasManager.CopySpriteToAtlas(PipeTileSheet, 0, 0, SpriteAtlas.AtlasType.Particle);
             byte[] pipeBytes = new byte[16 * 16 * 4];
-            GameState.SpriteAtlasManager.GetSpriteBytes(PipeSpriteIndex, pipeBytes);
+            GameState.SpriteAtlasManager.GetSpriteBytes(PipeSpriteIndex, pipeBytes, SpriteAtlas.AtlasType.Particle);
 
             byte[] bytes = new byte[32 * 32* 4];
 

--- a/Assets/Scripts/ParticlesTest.cs
+++ b/Assets/Scripts/ParticlesTest.cs
@@ -81,17 +81,17 @@ namespace PlanetTileMap.Unity
             int VentTileSheet = GameState.SpriteLoader.GetSpriteSheetID("Assets\\StreamingAssets\\Moonbunker\\Tilesets\\Sprites\\Objects\\vent1.png", 16, 16);
 
 
-            int PipeSpriteIndex = GameState.SpriteAtlasManager.CopySpriteToAtlas(PipeTileSheet, 0, 0, 0);
+            int PipeSpriteIndex = GameState.SpriteAtlasManager.CopySpriteToAtlas(PipeTileSheet, 0, 0, SpriteAtlas.AtlasType.Particle);
             byte[] pipeBytes = new byte[16 * 16 * 4];
-            GameState.SpriteAtlasManager.GetSpriteBytes(PipeSpriteIndex, pipeBytes);
+            GameState.SpriteAtlasManager.GetSpriteBytes(PipeSpriteIndex, pipeBytes, SpriteAtlas.AtlasType.Particle);
 
-            int OreSpriteIndex = GameState.SpriteAtlasManager.CopySpriteToAtlas(OreTileSheet, 0, 0, 0);
+            int OreSpriteIndex = GameState.SpriteAtlasManager.CopySpriteToAtlas(OreTileSheet, 0, 0, SpriteAtlas.AtlasType.Particle);
             byte[] oreBytes = new byte[16 * 16 * 4];
-            GameState.SpriteAtlasManager.GetSpriteBytes(OreSpriteIndex, oreBytes);
+            GameState.SpriteAtlasManager.GetSpriteBytes(OreSpriteIndex, oreBytes, SpriteAtlas.AtlasType.Particle);
 
-            int VentSpriteIndex = GameState.SpriteAtlasManager.CopySpriteToAtlas(VentTileSheet, 0, 0, 0);
+            int VentSpriteIndex = GameState.SpriteAtlasManager.CopySpriteToAtlas(VentTileSheet, 0, 0, SpriteAtlas.AtlasType.Particle);
             byte[] ventBytes = new byte[16 * 16 * 4];
-            GameState.SpriteAtlasManager.GetSpriteBytes(VentSpriteIndex, ventBytes);
+            GameState.SpriteAtlasManager.GetSpriteBytes(VentSpriteIndex, ventBytes, SpriteAtlas.AtlasType.Particle);
 
             PipeSprite = CreateTextureFromRGBA(pipeBytes, 16, 16);
             OreSprite = CreateTextureFromRGBA(oreBytes, 16, 16);

--- a/Assets/Scripts/SpriteAtlasTest.cs
+++ b/Assets/Scripts/SpriteAtlasTest.cs
@@ -89,12 +89,12 @@ namespace PlanetTileMap.Unity
             // we can blit the same sprite
             // but its only for testing purpose
             // we should remove that in the future
-            GameState.SpriteAtlasManager.CopySpriteToAtlas(SomeObjectTileSheet, 0, 0, 0);
-            GameState.SpriteAtlasManager.CopySpriteToAtlas(PlayerTileSheet, 0, 0, 0);;
-            GameState.SpriteAtlasManager.CopySpriteToAtlas(PlayerTileSheet, 0, 0, 0);
-            GameState.SpriteAtlasManager.CopySpriteToAtlas(SomeObjectTileSheet, 0, 0, 0);
-            GameState.SpriteAtlasManager.CopySpriteToAtlas(PlayerTileSheet, 0, 0, 0);
-            GameState.SpriteAtlasManager.CopySpriteToAtlas(PlayerTileSheet, 0, 0, 0);
+            GameState.SpriteAtlasManager.CopySpriteToAtlas(SomeObjectTileSheet, 0, 0, SpriteAtlas.AtlasType.Generic);
+            GameState.SpriteAtlasManager.CopySpriteToAtlas(PlayerTileSheet, 0, 0, SpriteAtlas.AtlasType.Generic);;
+            GameState.SpriteAtlasManager.CopySpriteToAtlas(PlayerTileSheet, 0, 0, SpriteAtlas.AtlasType.Generic);
+            GameState.SpriteAtlasManager.CopySpriteToAtlas(SomeObjectTileSheet, 0, 0, SpriteAtlas.AtlasType.Generic);
+            GameState.SpriteAtlasManager.CopySpriteToAtlas(PlayerTileSheet, 0, 0, SpriteAtlas.AtlasType.Generic);
+            GameState.SpriteAtlasManager.CopySpriteToAtlas(PlayerTileSheet, 0, 0, SpriteAtlas.AtlasType.Generic);
         }
 
         // drawing the sprite atlas

--- a/Assets/src/Sprites/SpriteAtlasManager.cs
+++ b/Assets/src/Sprites/SpriteAtlasManager.cs
@@ -5,6 +5,15 @@ using UnityEngine;
 
 namespace SpriteAtlas
 {
+    public enum AtlasType
+    {
+        Error = 0,
+        Generic = 1,
+        Agent = 2,
+        Vehicule = 3,
+        Particle = 4,
+    }
+
     public struct SpriteAtlas
     {
         public int AtlasID;
@@ -20,42 +29,40 @@ namespace SpriteAtlas
     
     public class SpriteAtlasManager
     {
-        private SpriteAtlas[] SpritesArray;
+        private SpriteAtlas[] AtlasArray;
 
         public SpriteAtlasManager()
         {
-            SpritesArray = new SpriteAtlas[1];
+            AtlasArray = new SpriteAtlas[Enum.GetNames(typeof(AtlasType)).Length - 1];
 
-            SpriteAtlas atlas = new SpriteAtlas();
-            atlas.Width = 128;
-            atlas.Height = 128;
-            atlas.Data = new byte[4 * atlas.Width * atlas.Height]; // 4 * 32 * 32 = 4096
-            atlas.Rectangles = new RectpackSharp.PackingRectangle[0];
-
-            for(int i = 0; i < atlas.Data.Length; i++)
+            for (int i = 0; i < AtlasArray.Length; i++)
             {
-                atlas.Data[i] = 255;
-            }
+                SpriteAtlas atlas = new SpriteAtlas();
+                atlas.Width = 128;
+                atlas.Height = 128;
+                atlas.Data = new byte[4 * atlas.Width * atlas.Height]; // 4 * 32 * 32 = 4096
+                atlas.Rectangles = new RectpackSharp.PackingRectangle[0];
 
-            SpritesArray[0] = atlas;
+                for(int j = 0; j < atlas.Data.Length; j++)
+                {
+                    atlas.Data[j] = 255;
+                }
+
+                AtlasArray[i] = atlas;
+            }
+        }
+
+        public ref SpriteAtlas GetSpriteAtlas(AtlasType type)
+        {
+            return ref AtlasArray[(int)type - 1];
         }
         
-        public ref SpriteAtlas GetSpriteAtlas(int id)
-        {
-            return ref SpritesArray[id];
-        }
-
-        public int GetGlTextureId(int id)
-        {
-            SpriteAtlas atlas = GetSpriteAtlas(id);
-            return atlas.GLTextureID;
-        }
 
         // use the id to find the Sprite coordinates in the list
         // and return the sprite RGBA8 that correspond
-        public void GetSpriteBytes(int id, byte[] data)
+        public void GetSpriteBytes(int id, byte[] data, AtlasType type)
         {
-            ref SpriteAtlas atlas = ref SpritesArray[0];
+            ref SpriteAtlas atlas = ref GetSpriteAtlas(type);
             if (id >= 0 && id < atlas.Rectangles.Length)
             {
                 // TODO: Refactor
@@ -93,9 +100,9 @@ namespace SpriteAtlas
 
         // generic blit function used to add a sprite 
         // to the sprite atlas
-        public int CopySpriteToAtlas(int spriteSheetID, int row, int column, int atlasId)
+        public int CopySpriteToAtlas(int spriteSheetID, int row, int column, AtlasType type)
         {
-            ref SpriteAtlas atlas = ref SpritesArray[atlasId];
+            ref SpriteAtlas atlas = ref GetSpriteAtlas(type);
             int oldSize = atlas.Rectangles.Length;
             SpriteLoader.SpriteSheet sheet = GameState.SpriteLoader.SpriteSheets[spriteSheetID];
 

--- a/Assets/src/Tiles/TileProperties/TileCreationApi.cs
+++ b/Assets/src/Tiles/TileProperties/TileCreationApi.cs
@@ -114,7 +114,7 @@ namespace TileProperties
             if (CurrentTileIndex != -1)
             {
                 int atlasSpriteId = 
-                    GameState.TileSpriteAtlasManager.CopySpriteToAtlas(spriteSheetId, row, column, 0);
+                    GameState.TileSpriteAtlasManager.CopyTileSpriteToAtlas(spriteSheetId, row, column, 0);
                 PropertiesArray[CurrentTileIndex].SpriteId = atlasSpriteId;
             }
         }
@@ -123,7 +123,7 @@ namespace TileProperties
         {
             if (CurrentTileIndex == -1) return;
             
-            int atlasSpriteId = GameState.TileSpriteAtlasManager.CopySpriteToAtlas16To32(spriteSheetId, row, column, 0);
+            int atlasSpriteId = GameState.TileSpriteAtlasManager.CopyTileSpriteToAtlas16To32(spriteSheetId, row, column, 0);
             PropertiesArray[CurrentTileIndex].SpriteId = atlasSpriteId;
         }
 
@@ -175,7 +175,7 @@ namespace TileProperties
                 if (PropertiesArray[CurrentTileIndex].VariantCount < PropertiesArray[CurrentTileIndex].Variants.Length)
                 {
                     int atlasSpriteId = 
-                        GameState.TileSpriteAtlasManager.CopySpriteToAtlas(spriteSheetId, row, column, 0);
+                        GameState.TileSpriteAtlasManager.CopyTileSpriteToAtlas(spriteSheetId, row, column, 0);
                     PropertiesArray[CurrentTileIndex].Variants[PropertiesArray[CurrentTileIndex].VariantCount++] = atlasSpriteId;
                 }
             }
@@ -188,7 +188,7 @@ namespace TileProperties
                 if (PropertiesArray[CurrentTileIndex].VariantCount < PropertiesArray[CurrentTileIndex].Variants.Length)
                 {
                     int atlasSpriteId = 
-                        GameState.TileSpriteAtlasManager.CopySpriteToAtlas16To32(spriteSheetId, row, column, 0);
+                        GameState.TileSpriteAtlasManager.CopyTileSpriteToAtlas16To32(spriteSheetId, row, column, 0);
                     PropertiesArray[CurrentTileIndex].Variants[PropertiesArray[CurrentTileIndex].VariantCount++] = atlasSpriteId;
                 }
             }

--- a/Assets/src/Tiles/TileSpriteAtlas/TileSpriteAtlasManager.cs
+++ b/Assets/src/Tiles/TileSpriteAtlas/TileSpriteAtlasManager.cs
@@ -55,8 +55,10 @@ namespace TileSpriteAtlas
             }
         }
 
-        // Returns sprite sheet id
-        public int CopySpriteToAtlas(int spriteSheetID, int row, int column, int atlasId)
+        // Copies a tile sprite from the Tile sprite sheet
+        // to the Tile Sprite Atlas
+        // returns an id that can be used later to get texture coordinates
+        public int CopyTileSpriteToAtlas(int spriteSheetID, int row, int column, int atlasId)
         {
             SpriteSheet sheet = GameState.TileSpriteLoader.SpriteSheets[spriteSheetID];
             ref TileSpriteAtlas atlas = ref SpritesArray[atlasId];
@@ -85,8 +87,10 @@ namespace TileSpriteAtlas
             return count - 1;
         }
 
-
-         public int CopySpriteToAtlas16To32(int spriteSheetID, int row, int column, int atlasId)
+        // Copies a 16x16 tile sprite from the Tile sprite sheet
+        // to the Tile Sprite Atlas
+        // returns an id that can be used later to get texture coordinates
+         public int CopyTileSpriteToAtlas16To32(int spriteSheetID, int row, int column, int atlasId)
         {
             SpriteSheet sheet = GameState.TileSpriteLoader.SpriteSheets[spriteSheetID];
             ref TileSpriteAtlas atlas = ref SpritesArray[atlasId];
@@ -124,7 +128,10 @@ namespace TileSpriteAtlas
         }
         
 
-        public int CopySpriteToAtlas8To32(int spriteSheetID, int row, int column, int atlasId)
+        // Copies a 8x8 tile sprite from the Tile sprite sheet
+        // to the Tile Sprite Atlas
+        // returns an id that can be used later to get texture coordinates
+        public int CopyTileSpriteToAtlas8To32(int spriteSheetID, int row, int column, int atlasId)
         {
             SpriteSheet sheet = GameState.TileSpriteLoader.SpriteSheets[spriteSheetID];
             ref TileSpriteAtlas atlas = ref SpritesArray[atlasId];

--- a/Assets/src/Vehicle/Systems/VehicleDrawSystem.cs
+++ b/Assets/src/Vehicle/Systems/VehicleDrawSystem.cs
@@ -52,12 +52,12 @@ namespace Systems
             int _spriteID = GameState.SpriteLoader.GetSpriteSheetID(_filePath, _width, _height);
 
             // Blit
-            int imageSpriteIndex = GameState.SpriteAtlasManager.CopySpriteToAtlas(_spriteID, 0, 0, 0);
+            int imageSpriteIndex = GameState.SpriteAtlasManager.CopySpriteToAtlas(_spriteID, 0, 0, SpriteAtlas.AtlasType.Vehicule);
             // Calculating Bytes
             byte[] imageBytes = new byte[_width * _height * 4];
 
             // Get Sprite Bytes
-            GameState.SpriteAtlasManager.GetSpriteBytes(imageSpriteIndex, imageBytes);
+            GameState.SpriteAtlasManager.GetSpriteBytes(imageSpriteIndex, imageBytes, SpriteAtlas.AtlasType.Vehicule);
 
             // Creating Texture
             vehicleSprite = CreateTextureFromRGBA(imageBytes, _width, _height);

--- a/Assets/src/agents/systems/AgentDrawSystem.cs
+++ b/Assets/src/agents/systems/AgentDrawSystem.cs
@@ -28,7 +28,7 @@ namespace Agent
             foreach (var agent in agents.agentsWithSprite)
             {
                 byte[] spriteBytes = new byte[agent.sprite2D.Size.x * agent.sprite2D.Size.y * 4];
-                GameState.SpriteAtlasManager.GetSpriteBytes(agent.sprite2D.AtlasIndex, spriteBytes);
+                GameState.SpriteAtlasManager.GetSpriteBytes(agent.sprite2D.AtlasIndex, spriteBytes, SpriteAtlas.AtlasType.Particle);
                 
                 var tex = CreateTextureFromRGBA(spriteBytes, agent.sprite2D.Size.x, agent.sprite2D.Size.y);
                 var mat = Object.Instantiate(agent.sprite2D.Material);

--- a/Assets/src/agents/systems/AgentSpawnerSystem.cs
+++ b/Assets/src/agents/systems/AgentSpawnerSystem.cs
@@ -12,7 +12,7 @@ namespace Agent
             
             var spriteSize = new Vector2Int(32, 48);
             var spriteID = GameState.SpriteLoader.GetSpriteSheetID("Assets\\StreamingAssets\\Moonbunker\\Tilesets\\Sprites\\character\\character.png", spriteSize.x, spriteSize.y);
-            var atlasIndex = GameState.SpriteAtlasManager.CopySpriteToAtlas(spriteID, 0, 0, 0);
+            var atlasIndex = GameState.SpriteAtlasManager.CopySpriteToAtlas(spriteID, 0, 0, SpriteAtlas.AtlasType.Agent);
             entity.AddSprite2D(atlasIndex, parent, material, spriteSize);
 
             entity.AddPosition2D(new Vector2(3f, 2f), default);


### PR DESCRIPTION
We have more sprite atlas sheets available to the user
Sprite Atlas id 0 is now an error
We can access a sprite atlas by specifying the type
  public enum AtlasType
  {
      Error = 0,
      Generic = 1,
      Agent = 2,
      Vehicule = 3,
      Particle = 4,
  }



