### PR TITLE
material type

### DIFF
--- a/Assets/Scripts/Test/LargePlanetTest.cs
+++ b/Assets/Scripts/Test/LargePlanetTest.cs
@@ -136,7 +136,7 @@ namespace Planet.Unity
                     }
 
 
-                    tileMap.SetFrontTile(i, j, frontTileID);
+                    tileMap.GetTile(i, j).FrontTileID = frontTileID;
                 }
             }
 
@@ -205,9 +205,9 @@ namespace Planet.Unity
             var camera = Camera.main;
             Vector3 lookAtPosition = camera.ScreenToWorldPoint(new Vector3(Screen.width / 2, Screen.height / 2, camera.nearClipPlane));
 
-            //tileMap.UpdateBackTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
-            //tileMap.UpdateMidTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
-            //tileMap.UpdateFrontTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
+            tileMap.UpdateBackTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
+            tileMap.UpdateMidTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
+            tileMap.UpdateFrontTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
 
         }
 

--- a/Assets/Scripts/Test/MovementSceneScript.cs
+++ b/Assets/Scripts/Test/MovementSceneScript.cs
@@ -51,9 +51,9 @@ namespace Planet.Unity
                 Vector3 lookAtPosition = camera.ScreenToWorldPoint(new Vector3(Screen.width / 2, Screen.height / 2, camera.nearClipPlane));
 
                 Planet.TileMap = TileMapManager.Load("generated-maps/movement-map.kmap", (int)lookAtPosition.x, (int)lookAtPosition.y);
-                //Planet.TileMap.UpdateBackTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
-                //Planet.TileMap.UpdateMidTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
-                //Planet.TileMap.UpdateFrontTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
+                Planet.TileMap.UpdateBackTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
+                Planet.TileMap.UpdateMidTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
+                Planet.TileMap.UpdateFrontTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
 
                 Debug.Log("loaded!");
             }
@@ -152,9 +152,9 @@ namespace Planet.Unity
 
             GenerateMap();
 
-            //Planet.TileMap.UpdateBackTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
-            //Planet.TileMap.UpdateMidTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
-            //Planet.TileMap.UpdateFrontTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
+            Planet.TileMap.UpdateBackTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
+            Planet.TileMap.UpdateMidTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
+            Planet.TileMap.UpdateFrontTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
 
             Player = Planet.AddPlayer(new Vec2f(3.0f, 20));
             PlayerID = Player.agentID.ID;
@@ -198,8 +198,8 @@ namespace Planet.Unity
             {
                 for(int i = 0; i < tileMap.MapSize.X; i++)
                 {
-                    tileMap.SetFrontTile(i, j, TileID.Moon);
-                    tileMap.SetBackTile(i, j, TileID.Background);
+                    tileMap.GetTile(i, j).FrontTileID = TileID.Moon;
+                    tileMap.GetTile(i, j).BackTileID = TileID.Background;
                 }
             }
 
@@ -207,29 +207,23 @@ namespace Planet.Unity
 
             for(int i = 0; i < tileMap.MapSize.X; i++)
             {
-                tileMap.SetFrontTile(i, 0, TileID.Bedrock);
-                tileMap.SetFrontTile(i, tileMap.MapSize.Y - 1, TileID.Bedrock);
+                tileMap.GetTile(i, 0).FrontTileID =  TileID.Bedrock;
+                tileMap.GetTile(i, tileMap.MapSize.Y - 1).FrontTileID = TileID.Bedrock;
             }
 
             for(int j = 0; j < tileMap.MapSize.Y; j++)
             {
-                tileMap.SetFrontTile(0, j, TileID.Bedrock);
-                tileMap.SetFrontTile(tileMap.MapSize.X - 1, j, TileID.Bedrock);
+                tileMap.GetTile(0, j).FrontTileID = TileID.Bedrock;
+                tileMap.GetTile(tileMap.MapSize.X - 1, j).FrontTileID = TileID.Bedrock;
             }
 
-            //tileMap.SetFrontTile(8, 14, TileID.Platform);
-            //tileMap.SetFrontTile(9, 14, TileID.Platform);
-            //tileMap.SetFrontTile(10, 14, TileID.Platform);
-            //tileMap.SetFrontTile(11, 14, TileID.Platform);
-            //tileMap.SetFrontTile(12, 14, TileID.Platform);
-            //tileMap.SetFrontTile(13, 14, TileID.Platform);
+           /* tileMap.SetFrontTile(8, 14, TileID.Platform);
+            tileMap.SetFrontTile(9, 14, TileID.Platform);
+            tileMap.SetFrontTile(10, 14, TileID.Platform);
+            tileMap.SetFrontTile(11, 14, TileID.Platform);
+            tileMap.SetFrontTile(12, 14, TileID.Platform);
+            tileMap.SetFrontTile(13, 14, TileID.Platform);*/
 
-            var camera = Camera.main;
-            Vector3 lookAtPosition = camera.ScreenToWorldPoint(new Vector3(Screen.width / 2, Screen.height / 2, camera.nearClipPlane));
-
-            //tileMap.UpdateBackTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
-            //tileMap.UpdateMidTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
-            //tileMap.UpdateFrontTileMapPositions((int)lookAtPosition.x, (int)lookAtPosition.y);
         }
 
     }

--- a/Assets/Scripts/Test/PlanetTest.cs
+++ b/Assets/Scripts/Test/PlanetTest.cs
@@ -356,22 +356,22 @@ namespace Planet.Unity
 
                 for (int j = carveHeight; j < tileMap.MapSize.Y && j < carveHeight + 4; j++)
                 {
-                    tileMap.SetFrontTile(i, j, TileID.Air);
-                    tileMap.SetMidTile(i, j, TileID.Pipe);
+                    tileMap.GetTile(i, j).FrontTileID = TileID.Air;
+                    tileMap.GetTile(i, j).MidTileID =  TileID.Pipe;
                 }
             }
 
 
             for(int i = 0; i < tileMap.MapSize.X; i++)
             {
-                tileMap.SetFrontTile(i, 0, TileID.Bedrock);
-                tileMap.SetFrontTile(i, tileMap.MapSize.Y - 1, TileID.Bedrock);
+                tileMap.GetTile(i, 0).FrontTileID = TileID.Bedrock;
+                tileMap.GetTile(i, tileMap.MapSize.Y - 1).FrontTileID = TileID.Bedrock;
             }
 
             for(int j = 0; j < tileMap.MapSize.Y; j++)
             {
-                tileMap.SetFrontTile(0, j, TileID.Bedrock);
-                tileMap.SetFrontTile(tileMap.MapSize.X - 1, j, TileID.Bedrock);
+                tileMap.GetTile(0, j).FrontTileID = TileID.Bedrock;
+                tileMap.GetTile(tileMap.MapSize.X - 1, j).FrontTileID = TileID.Bedrock;
             }
 
             var camera = Camera.main;

--- a/Assets/Source/GameManager/GameResources.cs
+++ b/Assets/Source/GameManager/GameResources.cs
@@ -155,12 +155,14 @@ public class GameResources
                             GameState.TileSpriteAtlasManager.CopyTileSpriteToAtlas(LoadingTilePlaceholderSpriteSheet, 0, 0, 0);
 
         GameState.TileCreationApi.CreateTileProperty(TileID.Ore1);
+        GameState.TileCreationApi.SetTileMaterialType(MaterialType.Ore1);
         GameState.TileCreationApi.SetTilePropertyName("ore_1");
         GameState.TileCreationApi.SetTilePropertyShape(TileShape.FullBlock);
         GameState.TileCreationApi.SetTilePropertyTexture16(OreSpriteSheet, 0, 0);
         GameState.TileCreationApi.EndTileProperty();
 
         GameState.TileCreationApi.CreateTileProperty(TileID.Glass);
+        GameState.TileCreationApi.SetTileMaterialType(MaterialType.Glass);
         GameState.TileCreationApi.SetTilePropertyName("glass");
         GameState.TileCreationApi.SetTilePropertyShape(TileShape.FullBlock);
         GameState.TileCreationApi.SetSpriteRuleType(PlanetTileMap.SpriteRuleType.R3);
@@ -169,6 +171,7 @@ public class GameResources
 
 
         GameState.TileCreationApi.CreateTileProperty(TileID.Moon);
+        GameState.TileCreationApi.SetTileMaterialType(MaterialType.Moon);
         GameState.TileCreationApi.SetTilePropertyName("moon");
         GameState.TileCreationApi.SetTilePropertyShape(TileShape.FullBlock);
         GameState.TileCreationApi.SetSpriteRuleType(PlanetTileMap.SpriteRuleType.R3);
@@ -176,6 +179,7 @@ public class GameResources
         GameState.TileCreationApi.EndTileProperty();
 
         GameState.TileCreationApi.CreateTileProperty(TileID.Background);
+        GameState.TileCreationApi.SetTileMaterialType(MaterialType.Background);
         GameState.TileCreationApi.SetTilePropertyName("background");
         GameState.TileCreationApi.SetSpriteRuleType(PlanetTileMap.SpriteRuleType.R3);
         GameState.TileCreationApi.SetTilePropertySpriteSheet16(BackgroundSpriteSheet, 0, 0);
@@ -183,6 +187,7 @@ public class GameResources
 
 
         GameState.TileCreationApi.CreateTileProperty(TileID.Ore2);
+        GameState.TileCreationApi.SetTileMaterialType(MaterialType.Ore2);
         GameState.TileCreationApi.SetTilePropertyName("ore_2");
         GameState.TileCreationApi.SetTilePropertyShape(TileShape.FullBlock);
         GameState.TileCreationApi.SetTilePropertyTexture16(Ore2SpriteSheet, 0, 0);
@@ -190,12 +195,14 @@ public class GameResources
 
 
         GameState.TileCreationApi.CreateTileProperty(TileID.Ore3);
+        GameState.TileCreationApi.SetTileMaterialType(MaterialType.Ore3);
         GameState.TileCreationApi.SetTilePropertyName("ore_3");
         GameState.TileCreationApi.SetTilePropertyShape(TileShape.FullBlock);
         GameState.TileCreationApi.SetTilePropertyTexture16(Ore3SpriteSheet, 0, 0);
         GameState.TileCreationApi.EndTileProperty();
 
         GameState.TileCreationApi.CreateTileProperty(TileID.Pipe);
+        GameState.TileCreationApi.SetTileMaterialType(MaterialType.Pipe);
         GameState.TileCreationApi.SetTilePropertyName("pipe");
         GameState.TileCreationApi.SetTilePropertyShape(TileShape.FullBlock);
         GameState.TileCreationApi.SetSpriteRuleType(PlanetTileMap.SpriteRuleType.R2);
@@ -203,12 +210,14 @@ public class GameResources
         GameState.TileCreationApi.EndTileProperty();
 
         GameState.TileCreationApi.CreateTileProperty(TileID.Wire);
+        GameState.TileCreationApi.SetTileMaterialType(MaterialType.Wire);
         GameState.TileCreationApi.SetTilePropertyName("wire");
         GameState.TileCreationApi.SetSpriteRuleType(PlanetTileMap.SpriteRuleType.R2);
         GameState.TileCreationApi.SetTilePropertySpriteSheet16(PipeSpriteSheet, 4, 12);
         GameState.TileCreationApi.EndTileProperty();
 
         GameState.TileCreationApi.CreateTileProperty(TileID.Bedrock);
+        GameState.TileCreationApi.SetTileMaterialType(MaterialType.Bedrock);
         GameState.TileCreationApi.SetTilePropertyName("Bedrock");
         GameState.TileCreationApi.SetCannotBeRemoved(true);
         GameState.TileCreationApi.SetTilePropertyShape(TileShape.FullBlock);

--- a/Assets/Source/PlanetTileMap/MaterialType.cs
+++ b/Assets/Source/PlanetTileMap/MaterialType.cs
@@ -1,0 +1,19 @@
+namespace PlanetTileMap
+{
+
+
+    public enum MaterialType
+    {
+        Error = 0,
+        Air,
+        Ore1, // 8
+        Ore2,
+        Ore3,
+        Glass, // 9
+        Moon, // 10
+        Pipe,
+        Background,
+        Wire,
+        Bedrock
+    }
+}

--- a/Assets/Source/PlanetTileMap/MaterialType.cs.meta
+++ b/Assets/Source/PlanetTileMap/MaterialType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88ca4133470ce0d46a1835ff4c965106
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Source/PlanetTileMap/SpriteRule_R1.cs
+++ b/Assets/Source/PlanetTileMap/SpriteRule_R1.cs
@@ -10,7 +10,7 @@ namespace PlanetTileMap
     {
 
          // TODO: Refactor
-         public static TilePosition GetTilePosition(TileID[] neighbors, TileID materialType)
+         public static TilePosition GetTilePosition(MaterialType[] neighbors, MaterialType materialType)
          {
              int biggestMatch = 0;
              TilePosition tilePosition = 0;
@@ -34,7 +34,7 @@ namespace PlanetTileMap
  
  
          // TODO: Refactor
-         public static int CheckTile(TileID[] neighbors, TilePosition rules, TileID materialType)
+         public static int CheckTile(MaterialType[] neighbors, TilePosition rules, MaterialType materialType)
          {
              // 16 different values can be stored
              // using only 4 bits for the
@@ -79,39 +79,43 @@ namespace PlanetTileMap
              // we have 4 neighbors per tile
              // could be more but its 4 for now
              // right/left/down/up
-             var neighbors = new TileID[4];
+             var neighbors = new MaterialType[4];
  
              for (int i = 0; i < neighbors.Length; i++)
              {
-                 neighbors[i] = TileID.Air;
+                 neighbors[i] = MaterialType.Air;
              }
  
              if (x + 1 < tileMap.MapSize.X)
              {
                  ref var neighborTile = ref tileMap.GetTile(x + 1, y);
-                 neighbors[(int) Neighbor.Right] = neighborTile.BackTileID;
+                 MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                 neighbors[(int) Neighbor.Right] = neighborMaterialType;
              }
  
              if (x - 1 >= 0)
              {
                  ref var neighborTile = ref tileMap.GetTile(x - 1, y);
-                 neighbors[(int) Neighbor.Left] = neighborTile.BackTileID;
+                 MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                 neighbors[(int) Neighbor.Left] = neighborMaterialType;
              }
  
              if (y + 1 < tileMap.MapSize.Y)
              {
                  ref var neighborTile = ref tileMap.GetTile(x, y + 1);
-                 neighbors[(int) Neighbor.Up] = neighborTile.BackTileID;
+                 MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                 neighbors[(int) Neighbor.Up] = neighborMaterialType;
              }
  
              if (y - 1 >= 0)
              {
                  ref var neighborTile = ref tileMap.GetTile(x, y - 1);
-                 neighbors[(int) Neighbor.Down] = neighborTile.BackTileID;
+                 MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                 neighbors[(int) Neighbor.Down] = neighborMaterialType;
              }
  
  
-             var tilePosition = GetTilePosition(neighbors, tile.BackTileID);
+             var tilePosition = GetTilePosition(neighbors, tileProperty.MaterialType);
  
              // the sprite ids are next to each other in the sprite atlas
              // we just have to know which one to draw based on the offset
@@ -138,39 +142,43 @@ namespace PlanetTileMap
              // we have 4 neighbors per tile
              // could be more but its 4 for now
              // right/left/down/up
-             var neighbors = new TileID[4];
+             var neighbors = new MaterialType[4];
  
              for (int i = 0; i < neighbors.Length; i++)
              {
-                 neighbors[i] = TileID.Air;
+                 neighbors[i] = MaterialType.Air;
              }
  
              if (x + 1 < tileMap.MapSize.X)
              {
                  ref var neighborTile = ref tileMap.GetTile(x + 1, y);
-                 neighbors[(int) Neighbor.Right] = neighborTile.MidTileID;
+                 MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                 neighbors[(int) Neighbor.Right] = neighborMaterialType;
              }
  
              if (x - 1 >= 0)
              {
                  ref var neighborTile = ref tileMap.GetTile(x - 1, y);
-                 neighbors[(int) Neighbor.Left] = neighborTile.MidTileID;
+                 MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                 neighbors[(int) Neighbor.Left] = neighborMaterialType;
              }
  
              if (y + 1 < tileMap.MapSize.Y)
              {
                  ref var neighborTile = ref tileMap.GetTile(x, y + 1);
-                 neighbors[(int) Neighbor.Up] = neighborTile.MidTileID;
+                 MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                 neighbors[(int) Neighbor.Up] = neighborMaterialType;
              }
  
              if (y - 1 >= 0)
              {
                  ref var neighborTile = ref tileMap.GetTile(x, y - 1);
-                 neighbors[(int) Neighbor.Down] = neighborTile.MidTileID;
+                 MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                 neighbors[(int) Neighbor.Down] = neighborMaterialType;
              }
  
  
-             var tilePosition = GetTilePosition(neighbors, tile.MidTileID);
+             var tilePosition = GetTilePosition(neighbors, tileProperty.MaterialType);
  
              // the sprite ids are next to each other in the sprite atlas
              // we just have to know which one to draw based on the offset
@@ -196,39 +204,43 @@ namespace PlanetTileMap
              // we have 4 neighbors per tile
              // could be more but its 4 for now
              // right/left/down/up
-             var neighbors = new TileID[4];
+             var neighbors = new MaterialType[4];
  
              for (int i = 0; i < neighbors.Length; i++)
              {
-                 neighbors[i] = TileID.Air;
+                 neighbors[i] = MaterialType.Air;
              }
  
              if (x + 1 < tileMap.MapSize.X)
              {
                  ref var neighborTile = ref tileMap.GetTile(x + 1, y);
-                 neighbors[(int) Neighbor.Right] = neighborTile.FrontTileID;
+                 MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                 neighbors[(int) Neighbor.Right] = neighborMaterialType;
              }
  
              if (x - 1 >= 0)
              {
                  ref var neighborTile = ref tileMap.GetTile(x - 1, y);
-                 neighbors[(int) Neighbor.Left] = neighborTile.FrontTileID;
+                 MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                 neighbors[(int) Neighbor.Left] = neighborMaterialType;
              }
  
              if (y + 1 < tileMap.MapSize.Y)
              {
                  ref var neighborTile = ref tileMap.GetTile(x, y + 1);
-                 neighbors[(int) Neighbor.Up] = neighborTile.FrontTileID;
+                 MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                 neighbors[(int) Neighbor.Up] = neighborMaterialType;
              }
  
              if (y - 1 >= 0)
              {
                  ref var neighborTile = ref tileMap.GetTile(x, y - 1);
-                 neighbors[(int) Neighbor.Down] = neighborTile.FrontTileID;
+                 MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                 neighbors[(int) Neighbor.Down] = neighborMaterialType;
              }
  
  
-             var tilePosition = GetTilePosition(neighbors, tile.FrontTileID);
+             var tilePosition = GetTilePosition(neighbors, tileProperty.MaterialType);
  
              // the sprite ids are next to each other in the sprite atlas
              // we just have to know which one to draw based on the offset

--- a/Assets/Source/PlanetTileMap/SpriteRule_R2.cs
+++ b/Assets/Source/PlanetTileMap/SpriteRule_R2.cs
@@ -10,7 +10,7 @@ namespace PlanetTileMap
     {
 
          // TODO: Refactor
-        public static TilePosition GetTilePosition(TileID[] neighbors, TileID materialType)
+        public static TilePosition GetTilePosition(MaterialType[] neighbors, MaterialType materialType)
         {
             int biggestMatch = 0;
             TilePosition tilePosition = 0;
@@ -34,7 +34,7 @@ namespace PlanetTileMap
 
 
         // TODO: Refactor
-        public static int CheckTile(TileID[] neighbors, TilePosition rules, TileID materialType)
+        public static int CheckTile(MaterialType[] neighbors, TilePosition rules, MaterialType materialType)
         {
             // 16 different values can be stored
             // using only 4 bits for the
@@ -79,39 +79,43 @@ namespace PlanetTileMap
             // we have 4 neighbors per tile
             // could be more but its 4 for now
             // right/left/down/up
-            var neighbors = new TileID[4];
+            var neighbors = new MaterialType[4];
 
             for (int i = 0; i < neighbors.Length; i++)
             {
-                neighbors[i] = TileID.Air;
+                neighbors[i] = MaterialType.Air;
             }
 
             if (x + 1 < tileMap.MapSize.X)
             {
                 ref var neighborTile = ref tileMap.GetTile(x + 1, y);
-                neighbors[(int) Neighbor.Right] = neighborTile.BackTileID;
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                neighbors[(int) Neighbor.Right] = neighborMaterialType;
             }
 
             if (x - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x - 1, y);
-                neighbors[(int) Neighbor.Left] = neighborTile.BackTileID;
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                neighbors[(int) Neighbor.Left] = neighborMaterialType;
             }
 
             if (y + 1 < tileMap.MapSize.Y)
             {
                 ref var neighborTile = ref tileMap.GetTile(x, y + 1);
-                neighbors[(int) Neighbor.Up] = neighborTile.BackTileID;
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                neighbors[(int) Neighbor.Up] = neighborMaterialType;
             }
 
             if (y - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x, y - 1);
-                neighbors[(int) Neighbor.Down] = neighborTile.BackTileID;
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                neighbors[(int) Neighbor.Down] = neighborMaterialType;
             }
 
 
-            var tilePosition = GetTilePosition(neighbors, tile.BackTileID);
+            var tilePosition = GetTilePosition(neighbors, tileProperty.MaterialType);
 
             // the sprite ids are next to each other in the sprite atlas
             // we just have to know which one to draw based on the offset
@@ -136,39 +140,43 @@ namespace PlanetTileMap
             // we have 4 neighbors per tile
             // could be more but its 4 for now
             // right/left/down/up
-            var neighbors = new TileID[4];
+            var neighbors = new MaterialType[4];
 
             for (int i = 0; i < neighbors.Length; i++)
             {
-                neighbors[i] = TileID.Air;
+                neighbors[i] = MaterialType.Air;
             }
 
             if (x + 1 < tileMap.MapSize.X)
             {
                 ref var neighborTile = ref tileMap.GetTile(x + 1, y);
-                neighbors[(int) Neighbor.Right] = neighborTile.MidTileID;
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                neighbors[(int) Neighbor.Right] = neighborMaterialType;
             }
 
             if (x - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x - 1, y);
-                neighbors[(int) Neighbor.Left] = neighborTile.MidTileID;
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                neighbors[(int) Neighbor.Left] = neighborMaterialType;
             }
 
             if (y + 1 < tileMap.MapSize.Y)
             {
                 ref var neighborTile = ref tileMap.GetTile(x, y + 1);
-                neighbors[(int) Neighbor.Up] = neighborTile.MidTileID;
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                neighbors[(int) Neighbor.Up] = neighborMaterialType;
             }
 
             if (y - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x, y - 1);
-                neighbors[(int) Neighbor.Down] = neighborTile.MidTileID;
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                neighbors[(int) Neighbor.Down] = neighborMaterialType;
             }
 
 
-            var tilePosition = GetTilePosition(neighbors, tile.MidTileID);
+            var tilePosition = GetTilePosition(neighbors, tileProperty.MaterialType);
 
             // the sprite ids are next to each other in the sprite atlas
             // we just have to know which one to draw based on the offset
@@ -193,39 +201,43 @@ namespace PlanetTileMap
             // we have 4 neighbors per tile
             // could be more but its 4 for now
             // right/left/down/up
-            var neighbors = new TileID[4];
+            var neighbors = new MaterialType[4];
 
             for (int i = 0; i < neighbors.Length; i++)
             {
-                neighbors[i] = TileID.Air;
+                neighbors[i] = MaterialType.Air;
             }
 
             if (x + 1 < tileMap.MapSize.X)
             {
                 ref var neighborTile = ref tileMap.GetTile(x + 1, y);
-                neighbors[(int) Neighbor.Right] = neighborTile.FrontTileID;
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                neighbors[(int) Neighbor.Right] = neighborMaterialType;
             }
 
             if (x - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x - 1, y);
-                neighbors[(int) Neighbor.Left] = neighborTile.FrontTileID;
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                neighbors[(int) Neighbor.Left] = neighborMaterialType;
             }
 
             if (y + 1 < tileMap.MapSize.Y)
             {
                 ref var neighborTile = ref tileMap.GetTile(x, y + 1);
-                neighbors[(int) Neighbor.Up] = neighborTile.FrontTileID;
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                neighbors[(int) Neighbor.Up] = neighborMaterialType;
             }
 
             if (y - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x, y - 1);
-                neighbors[(int) Neighbor.Down] = neighborTile.FrontTileID;
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                neighbors[(int) Neighbor.Down] = neighborMaterialType;
             }
 
 
-            var tilePosition = GetTilePosition(neighbors, tile.FrontTileID);
+            var tilePosition = GetTilePosition(neighbors, tileProperty.MaterialType);
 
             // the sprite ids are next to each other in the sprite atlas
             // we just have to know which one to draw based on the offset

--- a/Assets/Source/PlanetTileMap/SpriteRule_R3.cs
+++ b/Assets/Source/PlanetTileMap/SpriteRule_R3.cs
@@ -900,7 +900,8 @@ namespace PlanetTileMap
             if (x + 1 < tileMap.MapSize.X)
             {
                 ref var neighborTile = ref tileMap.GetTile(x + 1, y);
-                if (neighborTile.FrontTileID == tile.FrontTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_Right;
                 }
@@ -911,7 +912,8 @@ namespace PlanetTileMap
             if (x - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x - 1, y);
-                if (neighborTile.FrontTileID == tile.FrontTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_Left;
                 }
@@ -922,7 +924,8 @@ namespace PlanetTileMap
             if (y + 1 < tileMap.MapSize.Y)
             {
                 ref var neighborTile = ref tileMap.GetTile(x, y + 1);
-                if (neighborTile.FrontTileID == tile.FrontTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_Up;
                 }
@@ -933,7 +936,8 @@ namespace PlanetTileMap
             if (y - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x, y - 1);
-                if (neighborTile.FrontTileID == tile.FrontTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_Down;
                 }
@@ -944,7 +948,8 @@ namespace PlanetTileMap
             if (x + 1 < tileMap.MapSize.X && y + 1 < tileMap.MapSize.Y)
             {
                 ref var neighborTile = ref tileMap.GetTile(x + 1, y + 1);
-                if (neighborTile.FrontTileID == tile.FrontTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_UpRight;
                 }
@@ -955,7 +960,8 @@ namespace PlanetTileMap
             if (x - 1 >= 0 && y + 1 < tileMap.MapSize.Y)
             {
                 ref var neighborTile = ref tileMap.GetTile(x - 1, y + 1);
-                if (neighborTile.FrontTileID == tile.FrontTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_UpLeft;
                 }
@@ -966,7 +972,8 @@ namespace PlanetTileMap
             if (x + 1 < tileMap.MapSize.X && y - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x + 1, y - 1);
-                if (neighborTile.FrontTileID == tile.FrontTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_DownRight;
                 }
@@ -977,7 +984,8 @@ namespace PlanetTileMap
             if (x - 1 >= 0 && y - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x - 1, y - 1);
-                if (neighborTile.FrontTileID == tile.FrontTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.FrontTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_DownLeft;
                 }
@@ -1009,7 +1017,8 @@ namespace PlanetTileMap
             if (x + 1 < tileMap.MapSize.X)
             {
                 ref var neighborTile = ref tileMap.GetTile(x + 1, y);
-                if (neighborTile.MidTileID == tile.MidTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_Right;
                 }
@@ -1020,7 +1029,8 @@ namespace PlanetTileMap
             if (x - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x - 1, y);
-                if (neighborTile.MidTileID == tile.MidTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_Left;
                 }
@@ -1031,7 +1041,8 @@ namespace PlanetTileMap
             if (y + 1 < tileMap.MapSize.Y)
             {
                 ref var neighborTile = ref tileMap.GetTile(x, y + 1);
-                if (neighborTile.MidTileID == tile.MidTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_Up;
                 }
@@ -1042,7 +1053,8 @@ namespace PlanetTileMap
             if (y - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x, y - 1);
-                if (neighborTile.MidTileID == tile.MidTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_Down;
                 }
@@ -1053,7 +1065,8 @@ namespace PlanetTileMap
             if (x + 1 < tileMap.MapSize.X && y + 1 < tileMap.MapSize.Y)
             {
                 ref var neighborTile = ref tileMap.GetTile(x + 1, y + 1);
-                if (neighborTile.MidTileID == tile.MidTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_UpRight;
                 }
@@ -1064,7 +1077,8 @@ namespace PlanetTileMap
             if (x - 1 >= 0 && y + 1 < tileMap.MapSize.Y)
             {
                 ref var neighborTile = ref tileMap.GetTile(x - 1, y + 1);
-                if (neighborTile.MidTileID == tile.MidTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_UpLeft;
                 }
@@ -1075,7 +1089,8 @@ namespace PlanetTileMap
             if (x + 1 < tileMap.MapSize.X && y - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x + 1, y - 1);
-                if (neighborTile.MidTileID == tile.MidTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_DownRight;
                 }
@@ -1086,7 +1101,8 @@ namespace PlanetTileMap
             if (x - 1 >= 0 && y - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x - 1, y - 1);
-                if (neighborTile.MidTileID == tile.MidTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.MidTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_DownLeft;
                 }
@@ -1121,7 +1137,8 @@ namespace PlanetTileMap
             if (x + 1 < tileMap.MapSize.X)
             {
                 ref var neighborTile = ref tileMap.GetTile(x + 1, y);
-                if (neighborTile.BackTileID == tile.BackTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_Right;
                 }
@@ -1132,7 +1149,8 @@ namespace PlanetTileMap
             if (x - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x - 1, y);
-                if (neighborTile.BackTileID == tile.BackTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_Left;
                 }
@@ -1143,7 +1161,8 @@ namespace PlanetTileMap
             if (y + 1 < tileMap.MapSize.Y)
             {
                 ref var neighborTile = ref tileMap.GetTile(x, y + 1);
-                if (neighborTile.BackTileID == tile.BackTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_Up;
                 }
@@ -1154,7 +1173,8 @@ namespace PlanetTileMap
             if (y - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x, y - 1);
-                if (neighborTile.BackTileID == tile.BackTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_Down;
                 }
@@ -1165,7 +1185,8 @@ namespace PlanetTileMap
             if (x + 1 < tileMap.MapSize.X && y + 1 < tileMap.MapSize.Y)
             {
                 ref var neighborTile = ref tileMap.GetTile(x + 1, y + 1);
-                if (neighborTile.BackTileID == tile.BackTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_UpRight;
                 }
@@ -1176,7 +1197,8 @@ namespace PlanetTileMap
             if (x - 1 >= 0 && y + 1 < tileMap.MapSize.Y)
             {
                 ref var neighborTile = ref tileMap.GetTile(x - 1, y + 1);
-                if (neighborTile.BackTileID == tile.BackTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_UpLeft;
                 }
@@ -1187,7 +1209,8 @@ namespace PlanetTileMap
             if (x + 1 < tileMap.MapSize.X && y - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x + 1, y - 1);
-                if (neighborTile.BackTileID == tile.BackTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_DownRight;
                 }
@@ -1198,7 +1221,8 @@ namespace PlanetTileMap
             if (x - 1 >= 0 && y - 1 >= 0)
             {
                 ref var neighborTile = ref tileMap.GetTile(x - 1, y - 1);
-                if (neighborTile.BackTileID == tile.BackTileID)
+                MaterialType neighborMaterialType = GameState.TileCreationApi.GetTileProperty(neighborTile.BackTileID).MaterialType;
+                if (neighborMaterialType == tileProperty.MaterialType)
                 {
                     neighborsBitField |= BitField_DownLeft;
                 }

--- a/Assets/Source/PlanetTileMap/TileCreationApi.cs
+++ b/Assets/Source/PlanetTileMap/TileCreationApi.cs
@@ -76,6 +76,13 @@ namespace PlanetTileMap
             CurrentTileIndex = tileID;
         }
 
+        public void SetTileMaterialType(MaterialType materialType)
+        {
+            if (CurrentTileIndex == TileID.Error) return;
+
+            TilePropertyArray[(int) CurrentTileIndex].MaterialType = materialType;
+        }
+
         public void SetTilePropertyShape(TileShape shape)
         {
             if (CurrentTileIndex == TileID.Error) return;

--- a/Assets/Source/PlanetTileMap/TileProperty.cs
+++ b/Assets/Source/PlanetTileMap/TileProperty.cs
@@ -16,8 +16,10 @@ namespace PlanetTileMap
         public string Description; //later use string pool
         
         public TileID TileID;
+        public MaterialType MaterialType;
         public int BaseSpriteId;
         public TileDrawType DrawType;
+
 
         public byte Durability; //max health of tile
         


### PR DESCRIPTION
Added material Type to Tile Properties
fixed tile generation on large map and movement scene
Sprite Update rule now are based on material type instead of tile id